### PR TITLE
chore(*): remove wrong version 2.7.12

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -301,29 +301,6 @@ entries:
     - https://github.com/Kong/kong-mesh-charts/releases/download/kong-mesh-2.8.0/kong-mesh-2.8.0.tgz
     version: 2.8.0
   - apiVersion: v2
-    appVersion: 2.7.12
-    created: "2025-03-03T09:51:15.887454546Z"
-    dependencies:
-    - name: kuma
-      repository: https://kumahq.github.io/charts
-      version: 2.7.12
-    description: A Helm chart for Kong Mesh
-    digest: c42d18ce73e910f95696c4d7706d610976745886c3688ee29491c4ddcc4bd55d
-    home: https://docs.konghq.com/mesh/
-    icon: https://github.com/Kong/kong-mesh-charts/raw/master/artifacts/kong-mesh-square.png
-    keywords:
-    - Kong
-    - service mesh
-    - control plane
-    maintainers:
-    - email: jakub.dyszkiewicz@konghq.com
-      name: jakubdyszkiewicz
-    name: kong-mesh
-    type: application
-    urls:
-    - https://github.com/Kong/kong-mesh-charts/releases/download/kong-mesh-2.7.12/kong-mesh-2.7.12.tgz
-    version: 2.7.12
-  - apiVersion: v2
     appVersion: 2.7.11
     created: "2025-01-22T10:08:58.362491189Z"
     dependencies:


### PR DESCRIPTION
This version will be re-published by the CI. 

It ran into error last time at 
https://github.com/Kong/kong-mesh/actions/runs/13626865294/job/38089518304